### PR TITLE
Add project planning documentation and repository guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent Guidelines
+
+## Repository-Wide Expectations
+- Maintain the planning documents in the `docs/` directory. Update them whenever scope, features, or architecture change.
+- Keep `README.md` aligned with the current state of the project and reference newly added documents.
+- Preserve the data model and endpoint summaries when expanding functionality.
+
+## TODO Management
+- Always keep `TODO.md` up to date with feature status, milestones, and notes for future developers.
+- Update TODO items immediately after any relevant code or documentation changes.
+- Include context such as blockers, dependencies, and links to corresponding documents or tickets.
+
+## Development Workflow
+- Follow the feature roadmap defined in `docs/implementation_plan.md` unless requirements shift.
+- Ensure new endpoints, pages, or models include corresponding documentation updates.
+- Maintain auditability by noting significant design decisions in commit messages and documentation.
+
+## Communication
+- Summaries and PR descriptions should clearly state affected areas, testing performed, and any follow-up actions required.

--- a/README.md
+++ b/README.md
@@ -1,642 +1,82 @@
-BuyLyst.co
-
-BuyLyst.co is a full-stack Python + MongoDB + React application used by trading card game stores to manage their buylist intake, pricing, cart processing, and inventory importing. It is designed to enable customers to submit cards for sale, employees to process the physical cards, and managers to intake and sync the results into an inventory system (e.g., Shopify).
-
-
----
-
-✨ Overview
-
-Self-hosted Flask server with JWT auth and MongoDB storage
-
-Daily CSV imports from TCGCSV API for up-to-date product data
-
-Public buylist interface showing cards the store wants to buy
-
-Advanced cart system for buy requests and pricing enforcement
-
-Admin tools for setting buy prices, tracking buy progress, disabling categories/groups
-
-Employee workflows for processing carts in-store
-
-Manager workflows for intaking processed carts and generating exports
-
-Everything is logged and auditable
-
-
-
----
-
-🏛️ Technologies
-
-Layer	Stack
-
-Backend	Flask + Flask-JWT-Extended
-Database	MongoDB
-Scheduler	APScheduler
-Frontend	React + Tailwind (planned)
-Deployment	Bare metal, self-hosted
-
-
-
----
-
-🔢 Data Model Summary
-
-products
-
-Pulled from TCGCSV. Each product has:
-
-internalId = productId_subTypeName
-
-productId, groupId, categoryId
-
-name, imageUrl, tcgplayerUrl, rarity, number, subTypeName
-
-marketPrice, lowPrice, midPrice, highPrice, directLowPrice
-
-
-buylist_entries
-
-internalId
-
-priceMultiplier, priceOverride
-
-disabled: controls if it's shown to users
-
-createdBy, createdAt, updatedBy, updatedAt
-
-
-buylist_progress
-
-internalId, maxQuantity
-
-boughtQuantity, pendingQuantity
-
-Used to control auto-disable behavior
-
-
-buy_carts
-
-status: draft / submitted / accepted / processed / completed
-
-username, dropOffType, items, notes
-
-employeeName, processedBy
-
-payout.cash, payout.credit, payout.creditBonus
-
-Timestamps: createdAt, submittedAt, processedAt, cancelledAt
-
-
-users
-
-username, password_hash, role
-
-Roles: customer, employee, manager, admin
-
-
-server_settings
-
-storeName
-
-creditBoostPercentage
-
-conditionPercentages
-
-enabledCategories
-
-allowUserAccounts, allowInStoreDropOff, allowShippedDropOff
-
-
-audit_logs
-
-action, collection_name, document_id, performed_by, timestamp, details
-
-
-emergency_disables
-
-type: "group" or "category"
-
-id, reason, disabledBy, disabledAt
-
-
-
----
-
-🚀 Use Case Flow (User to Inventory)
-
-Diagram
-
-graph TD
-  A[Customer checks buylist] --> B[Adds 3x Fenrir to cart]
-  B --> C[Submits cart (in-store)]
-  C --> D[Admin optionally approves cart]
-  C --> E[Employee sees submitted cart]
-  E --> F[Processes cart: 2 NM, 1 LP]
-  F --> G[Customer selects $5 credit / rest cash]
-  G --> H[Cart stored w/ payout + audit log]
-  H --> I[Inventory Manager sees processed cart]
-  I --> J[Reviews: corrects to 2 LP, 1 NM]
-  J --> K[Marks cart reviewed]
-  K --> L[Selects batch to import]
-  L --> M[Generates CSV export for Shopify]
-  M --> N[Uploads to Shopify, stores inventory]
-
-
----
-
-✅ Features
-
-Customers
-
-Register/login with JWT
-
-View public buylist
-
-Fuzzy name search (e.g. "ka fen" -> "Kashtira Fenrir")
-
-Add to cart (auto-creates draft cart)
-
-Cannot exceed quantity limits
-
-Cannot submit emergency-disabled items
-
-Submit cart with drop-off type
-
-View/cancel own carts
-
-
-Admin
-
-Set priceMultiplier or priceOverride per product
-
-Enable/disable buylist entries
-
-Set maxQuantity for buy goals
-
-Auto-disable when max fulfilled
-
-View audit logs (paginated + filtered)
-
-Emergency disable groups/categories
-
-Update global settings
-
-View and modify user roles/passwords
-
-
-Employees
-
-View submitted + accepted carts
-
-Cancel submitted carts
-
-Process cart with adjusted conditions
-
-Apply payout splits (cash + credit)
-
-Auto-calculate credit bonus
-
-Add employee notes and name
-
-
-Inventory Managers
-
-(Planned) View processed carts
-
-(Planned) Mark reviewed, adjust final conditions/qtys
-
-(Planned) Generate import batch
-
-(Planned) Export to CSV for POS
-
-
-Import System
-
-Daily TCGCSV job by category
-
-Background thread processes queue
-
-Tracks current in-progress category
-
-Imports groups + products + prices
-
-Summarizes imported totals in log
-
-Skips products that already exist
-
-
-SKU Mapping
-
-(Planned) internalId -> { NM: SKU1, LP: SKU2, ... }
-
-Selenium fallback if SKU missing
-
-Manual entry UI if no listing found
-
-
-Area	Description
-
-Cart approval	Accept/lock in carts before processing
-Intake APIs	List processed carts, mark reviewed, fix issues
-Inventory import	Store reviewed products in inventory_imports
-CSV export	Create files for Shopify/etc
-Analytics	Weekly/monthly spending, buy summaries
-Manual SKU tool	Web UI to enter missing SKUs
-POS integration	Automatically sync payouts to POS
-
-
-
----
-
-🔗 API Summary
-
-Endpoint	Role	Description
-
-GET /buylist	public	Search cards available for buying
-POST /cart/add	customer	Add item to draft cart
-POST /cart/submit	customer	Submit cart for review
-GET /employee/cart/get/<id>	employee	View and process cart
-POST /employee/cart/process/<id>	employee	Mark cart as processed
-POST /admin/buylist	admin	Create or update a buylist entry
-GET /admin/audit_logs	admin	Paginated audit log viewer
-POST /admin/settings	admin	Update global server config
-GET /groups/all_by_category	public	Group list for filters/dropdowns
-
-
-
----
-
-⚡ Development Standards
-
-# MODIFIED comments required on all changed lines
-
-All DB write ops and logins must include AuditLog.log()
-
-Logging via central logger
-
-All _id fields must be stringified before returning
-
-Only one draft cart per user
-
-Every model uses .collection() to define indexes
-
-
-
----
-
-✍ Contributing Notes
-
-Run main.py directly to start API server
-
-.env file required with Mongo and JWT keys
-
-Use Postman to test endpoints with JWT
-
-Frontend (React) work is still upcoming
-
-
-
----
-
-Here is a step-by-step, technical walkthrough of the full buylist lifecycle using the "3x Fenrir" use-case — with explicit backend endpoint calls, method types, input payloads, and the DB behavior involved at each step.
-
-
----
-
-✅ Step-by-Step: Selling 3x Fenrir — Endpoint Flow
-
-
----
-
-1. Customer wants to check if we're buying "Fenrir"
-
-Action: Search the public buylist
-
-Endpoint:
-GET /buylist?name=fenrir
-(optional: &categoryId=1, &groupId=123, etc.)
-
-What Happens:
-
-Matches enabled buylist entries
-
-Applies emergency disables
-
-Joins buylist_entries, products, and buylist_progress
-
-Calculates:
-
-remainingQuantity = maxQuantity - boughtQuantity - pendingQuantity
-
-buyPrice = priceOverride OR priceMultiplier * marketPrice
-
-
-Returns:
-
-
-[
-  {
-    "internalId": "123-EN",
-    "name": "Fenrir",
-    "buyPrice": 5.00,
-    "remainingQuantity": 10
-  }
-]
-
-✅ Implemented via routes/public_buylist.py
-
-
----
-
-2. Customer registers an account
-
-Endpoint:
-POST /auth/register
-
-Body:
-
-{ "username": "fenrirfan", "password": "hunterxhunter" }
-
-✅ Implemented — conditional on server setting allowUserAccounts == true
-
-
----
-
-3. Customer adds 3x Fenrir to their cart
-
-Endpoint:
-POST /cart/add
-
-Body:
-
-{ "internalId": "123-EN", "quantity": 3 }
-
-What Happens:
-
-Validates that the product is enabled and not emergency-disabled
-
-Loads buylist entry + progress
-
-Ensures requested_quantity + bought + pending <= maxQuantity
-
-Creates a draft cart if needed
-
-Adds item or increments quantity
-
-Price and condition stored on item
-
-Audits the change
-
-
-✅ Implemented in public_cart.py
-
-
----
-
-4. Customer submits the cart
-
-Endpoint:
-POST /cart/submit
-
-What Happens:
-
-Changes cart status: "draft" → "submitted"
-
-Increments pendingQuantity in buylist_progress
-
-Audits the action
-
-
-✅ Implemented
-
-
----
-
-5. Admin reviews carts to approve or not
-
-Endpoint:
-GET /employee/cart/list_pending
-
-What Happens:
-
-Returns all carts with status submitted or accepted
-
-
-✅ Implemented
-
-
----
-
-6. Employee sees cart detail
-
-Endpoint:
-GET /employee/cart/get/<cart_id>
-
-What Happens:
-
-Returns cart contents
-
-If status is "submitted":
-
-Compares items against current buylist availability
-
-Flags any disabled or emergency-disabled items as "discontinued"
-
-
-
-✅ Implemented (with discontinuedItems list)
-
-
----
-
-7. Emergency disable applied to "Fenrir"
-
-Endpoint:
-POST /admin/emergency/disable
-
-Body:
-
-{ "type": "product", "id": "123-EN" } // or type = "group", "category"
-
-What Happens:
-
-Adds entry to emergency_disables
-
-Disables it from new add-to-cart actions and buylist visibility
-
-
-✅ Implemented (group/category only — product-level not supported yet)
-
-
----
-
-8. Customer comes in with cart ID
-
-No endpoint call here — they provide the cart ID to a store employee.
-
-
----
-
-9. Employee processes the cart
-
-Endpoint:
-POST /employee/cart/process/<cart_id>
-
-Body:
-
-{
-  "items": [
-    { "internalId": "123-EN", "quantity": 2, "condition": "Near Mint", "priceEach": 5.0 },
-    { "internalId": "123-EN", "quantity": 1, "condition": "Lightly Played", "priceEach": 5.0 }
-  ],
-  "employeeName": "Tom",
-  "notes": "1 lightly played",
-  "payout": {
-    "cashPercentage": 0.667,
-    "creditPercentage": 0.333
-  }
-}
-
-What Happens:
-
-Applies conditionPercentages and creditBoost from server settings
-
-Computes total payout in cash & credit
-
-Updates cart:
-
-"status": "processed"
-
-Logs payout, notes, condition details
-
-
-Updates boughtQuantity in buylist_progress
-
-Audits the change
-
-
-✅ Implemented
-
-
----
-
-10. Inventory manager sees list of processed carts
-
-Endpoint:
-GET /inventory/list_processed
-
-Returns: All carts with status "processed" (not yet intaked)
-
-🟡 Not implemented yet — Placeholder only
-
-
----
-
-11. Inventory manager edits actual received items
-
-Endpoint:
-POST /inventory/review/<cart_id>
-
-Body:
-
-{
-  "corrections": [
-    { "internalId": "123-EN", "correctedCondition": "Lightly Played", "correctedQuantity": 2 }
-  ],
-  "notes": "Two LP, not NM"
-}
-
-What Happens:
-
-Stores a new corrected intake section
-
-Preserves original processed state
-
-Allows later export of actual inventory import
-
-
-🟥 NOT implemented
-
-
----
-
-12. Manager confirms reviewed carts for import
-
-Endpoint:
-POST /inventory/finalize
-
-Body:
-
-{ "cartIds": ["abc123", "def456"] }
-
-What Happens:
-
-Aggregates product totals across all reviewed carts
-
-Creates inventory_imports document with summary + per-cart breakdown
-
-
-🟥 NOT implemented
-
-
----
-
-13. Manager exports inventory to CSV
-
-Endpoint:
-GET /inventory/export/<import_id>?format=shopify_csv
-
-What Happens:
-
-Generates a .csv (or downloadable buffer) with product SKUs + quantities
-
-Format depends on inventory system (Shopify, Square, etc.)
-
-
-🟥 NOT implemented
-
-
----
-
-14. Analytics: Spending by category, product, etc
-
-Endpoint (example):
-GET /analytics/spend_summary?categoryId=3&period=weekly
-
-What Happens:
-
-Aggregates processed or imported carts by category, group, or internalId
-
-Returns total quantity + spend breakdown
-
-
-🟥 NOT implemented
-
-
----
-
-✅ Summary of Endpoint Coverage
-
-Feature	Status	Notes
-
-Search public buylist	✅ Implemented	
-Register/Login/Auth	✅ Implemented	
-Add to cart / view current cart / submit	✅ Implemented	
-Emergency disables (category/group)	✅ Implemented	product-level disable not supported
-View pending carts (employee)	✅ Implemented	
-View single cart with discontinued detection	✅ Implemented	
-Process cart with conditions + payout	✅ Implemented	
-Cancel cart (customer or employee)	✅ Implemented	
-Inventory review workflow	🟥 Missing	step-by-step review logic
-Inventory correction and cart intake	🟥 Missing	needs actual vs processed state
-Inventory import + CSV export	🟥 Missing	format per POS
-Audit logs for all actions	✅ Implemented	
-Admin UI for settings, emergency disable, progress, and buylist config	✅ Implemented	
-Analytics endpoints for spend tracking	🟥 Missing	group/category/product filters
-
-
-
----
-
+<div align="center">
+
+# BuyLyst.co
+
+</div>
+
+BuyLyst.co is a full-stack Python + MongoDB + React application for trading card game stores to manage buylist intake, pricing, cart processing, and inventory importing. The platform enables customers to submit cards for sale, employees to validate physical cards, and managers to intake results into downstream inventory systems (e.g., Shopify).
+
+## Table of Contents
+- [Project Overview](#project-overview)
+- [Architecture](#architecture)
+- [Planning Documents](#planning-documents)
+- [Data Model Summary](#data-model-summary)
+- [Endpoint Coverage Snapshot](#endpoint-coverage-snapshot)
+- [Roadmap](#roadmap)
+- [Contributing](#contributing)
+
+## Project Overview
+- Self-hosted Flask server secured with JWT authentication and backed by MongoDB storage.
+- Daily CSV imports from the TCGCSV API to keep product data up to date.
+- Public buylist interface showing cards the store wants to buy with pricing enforcement.
+- Advanced cart system supporting condition-based payouts and drop-off workflows.
+- Administrative controls for pricing, progress tracking, and emergency disables.
+- Employee and manager workflows covering intake, review, inventory exports, and auditing.
+
+## Architecture
+| Layer       | Stack / Tooling              |
+|-------------|------------------------------|
+| Backend     | Flask, Flask-JWT-Extended    |
+| Database    | MongoDB                      |
+| Scheduler   | APScheduler                  |
+| Frontend    | React, Tailwind CSS (planned) |
+| Deployment  | Bare metal / self-hosted     |
+
+## Planning Documents
+- [User Story Narrative](docs/user_story_narrative.md)
+- [Required Features](docs/required_features.md)
+- [Backend Endpoints](docs/backend_endpoints.md)
+- [Frontend Pages](docs/frontend_pages.md)
+- [Database Collections & Models](docs/database_models.md)
+- [User Story Walkthrough](docs/user_story_walkthrough.md)
+- [Long-Term Implementation Plan](docs/implementation_plan.md)
+
+## Data Model Summary
+- **products**: Imported from TCGCSV; includes IDs, taxonomy, metadata, and price metrics.
+- **buylist_entries**: Store-defined pricing configuration and visibility controls per product.
+- **buylist_progress**: Tracks pending and processed quantities relative to max thresholds.
+- **buy_carts**: Customer submissions with status history, payouts, and processing details.
+- **users**: Authentication records with roles and contact preferences.
+- **server_settings**: Store policies, payout multipliers, and drop-off options.
+- **audit_logs**: Immutable record of significant actions and changes.
+- **emergency_disables**: Manual overrides for groups, categories, or specific products.
+- **inventory_imports**: Aggregated processed carts prepared for downstream inventory syncs.
+- **import_runs**: Execution metadata for scheduled data imports.
+- **analytics_cache**: Materialized analytics results for performance.
+
+## Endpoint Coverage Snapshot
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Search public buylist | ✅ Implemented | |
+| Register/Login/Auth | ✅ Implemented | |
+| Add to cart / view current cart / submit | ✅ Implemented | |
+| Emergency disables (category/group) | ✅ Implemented | Product-level disable not yet supported |
+| View pending carts (employee) | ✅ Implemented | |
+| View single cart with discontinued detection | ✅ Implemented | |
+| Process cart with conditions + payout | ✅ Implemented | |
+| Cancel cart (customer or employee) | ✅ Implemented | |
+| Inventory review workflow | 🟥 Missing | Needs step-by-step review logic |
+| Inventory correction and cart intake | 🟥 Missing | Requires actual vs processed state |
+| Inventory import + CSV export | 🟥 Missing | Format varies per POS |
+| Audit logs for all actions | ✅ Implemented | |
+| Admin UI for settings, emergency disable, progress, and buylist config | ✅ Implemented | |
+| Analytics endpoints for spend tracking | 🟥 Missing | Need group/category/product filters |
+
+## Roadmap
+High-level phases and milestones are detailed in the [Long-Term Implementation Plan](docs/implementation_plan.md). Key near-term goals include completing the inventory review workflow, implementing export capabilities, and delivering analytics dashboards.
+
+## Contributing
+1. Fork the repository and create a feature branch.
+2. Ensure planning documents remain updated for any scope changes.
+3. Write tests and documentation for new functionality.
+4. Submit a pull request describing changes, testing steps, and any migration considerations.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,49 @@
+# TODO & Status Tracker
+
+## Planning Documents
+- [x] Create detailed planning documentation set (user story, features, endpoints, frontend pages, models, walkthrough, long-term plan).
+- [x] Update README to reference new documents and summarize scope.
+- [x] Establish repository-wide agent guidelines.
+
+## Phase 0: Foundations
+- [ ] Define development environment setup instructions.
+- [ ] Configure CI/CD pipeline (linting, testing, security scans).
+- [ ] Provision shared MongoDB instances and seed datasets.
+- [ ] Implement authentication scaffold (JWT, roles) in codebase.
+
+## Phase 1: Public Buylist & Cart
+- [ ] Integrate TCGCSV import scheduler.
+- [ ] Build public buylist endpoints with filtering and search.
+- [ ] Implement React pages for buylist browsing and product detail.
+- [ ] Develop cart drafting and submission flow with validation.
+- [ ] Add submission notifications and status tracker UI.
+
+## Phase 2: Employee Processing
+- [ ] Create employee queue and cart acceptance APIs/UI.
+- [ ] Implement processing workspace with condition/payout tools.
+- [ ] Enable attachment upload handling and storage.
+- [ ] Expand audit logging for employee actions.
+
+## Phase 3: Manager Review & Inventory Intake
+- [ ] Build manager review dashboard and correction flows.
+- [ ] Implement inventory import batch creation and tracking endpoints.
+- [ ] Generate export files (Shopify CSV baseline) with validation.
+- [ ] Add reconciliation tools comparing processed vs corrected data.
+
+## Phase 4: Administration & Analytics
+- [ ] Deliver buylist management UI with emergency disable controls.
+- [ ] Implement system settings pages with guardrails and audit trails.
+- [ ] Build analytics dashboards and supporting APIs.
+- [ ] Introduce analytics caching and performance tuning.
+
+## Phase 5: Deployment & Operations
+- [ ] Prepare production deployment scripts (Docker/systemd) and documentation.
+- [ ] Configure monitoring and alerting (metrics, logs, uptime checks).
+- [ ] Establish backup/restore procedures for MongoDB and file storage.
+- [ ] Conduct load testing and performance tuning sessions.
+- [ ] Plan pilot rollout and feedback loop.
+
+## Notes & Dependencies
+- Align feature implementation with the [Long-Term Implementation Plan](docs/implementation_plan.md).
+- Update relevant documents and this tracker immediately after each feature milestone progresses.
+- Capture emerging risks, decisions, and follow-ups directly under the affected phase.

--- a/docs/backend_endpoints.md
+++ b/docs/backend_endpoints.md
@@ -1,0 +1,61 @@
+# Backend Endpoints
+
+## Authentication & Users
+- `POST /auth/register` — Create new customer accounts; validates configuration for allowing registrations.
+- `POST /auth/login` — Authenticate users and issue JWT tokens.
+- `POST /auth/refresh` — Refresh JWT access tokens using refresh tokens.
+- `GET /users/me` — Retrieve the authenticated user's profile and role.
+- `GET /users` (admin) — List users with pagination and filters.
+- `PATCH /users/{userId}` (admin) — Update role, status, or reset passwords.
+
+## Public Buylist
+- `GET /buylist/products` — Searchable list of active buylist entries with filters (category, group, price range, text query).
+- `GET /buylist/products/{internalId}` — Detailed product data including pricing, limits, and availability.
+- `GET /buylist/settings` — Exposes public configuration (store info, drop-off options, credit bonus).
+
+## Cart Management
+- `GET /carts/current` — Fetch the authenticated customer's draft cart.
+- `POST /carts` — Create or update a draft cart with items, drop-off preference, and notes.
+- `POST /carts/submit` — Validate and submit the current cart for processing.
+- `GET /carts/{cartId}` — Retrieve a specific cart with full history and status.
+- `GET /carts` (employee/manager) — List carts filtered by status (submitted, accepted, processed, etc.).
+- `POST /carts/{cartId}/cancel` — Cancel a cart by customer or staff with reason logging.
+
+## Employee Processing
+- `POST /processing/{cartId}/accept` — Mark a submitted cart as accepted for processing.
+- `POST /processing/{cartId}/items` — Record verified items, conditions, and payout adjustments.
+- `POST /processing/{cartId}/complete` — Finalize processing, including payout summary and audit trail.
+- `POST /processing/{cartId}/attachments` — Upload supporting documents or photos.
+
+## Inventory Review & Intake
+- `GET /inventory/processed` — List processed carts awaiting manager review.
+- `POST /inventory/review/{cartId}` — Submit corrections to processed cart items and notes.
+- `POST /inventory/finalize` — Confirm reviewed carts and create an inventory import batch.
+- `GET /inventory/imports` — List historical import batches with status metadata.
+- `GET /inventory/imports/{importId}` — View details of a specific import batch.
+- `GET /inventory/export/{importId}` — Generate export files (CSV, JSON) for downstream systems.
+
+## Buylist Configuration
+- `GET /admin/buylist` — Administrative view of all buylist entries, including disabled items.
+- `POST /admin/buylist` — Create or update buylist entries with price overrides and limits.
+- `PATCH /admin/buylist/{internalId}/status` — Enable or disable a product.
+- `GET /admin/progress` — Monitor buylist progress (max quantities, bought counts).
+- `POST /admin/emergency-disable` — Disable an entire group or category immediately.
+- `DELETE /admin/emergency-disable/{id}` — Remove an emergency disable rule.
+
+## System Settings & Integrations
+- `GET /admin/settings` — Retrieve server settings (store info, credit bonus, condition percentages).
+- `PATCH /admin/settings` — Update server settings with validation and audit logging.
+- `POST /admin/imports/tcgcsv` — Manually trigger a TCGCSV data import.
+- `GET /admin/imports/tcgcsv/runs` — View history and status of scheduled imports.
+- `GET /admin/audit-logs` — Query audit logs with filters (user, action, date range).
+
+## Analytics
+- `GET /analytics/spend-summary` — Aggregate spend and quantities by filters (category, group, product, date range).
+- `GET /analytics/employee-performance` — Metrics on processing throughput and accuracy.
+- `GET /analytics/inventory-impact` — Track inventory additions per import and product.
+
+## Health & Utility
+- `GET /health` — Service health check.
+- `GET /metrics` — Prometheus-compatible metrics endpoint.
+- `GET /docs` — API documentation explorer (Swagger/OpenAPI).

--- a/docs/database_models.md
+++ b/docs/database_models.md
@@ -1,0 +1,105 @@
+# Database Collections & Models
+
+## `products`
+- `internalId`: String (primary key, composed of `productId_subTypeName`).
+- `productId`: Integer (TCGCSV identifier).
+- `groupId`, `categoryId`: Integers for grouping and category taxonomy.
+- `name`, `number`, `rarity`, `subTypeName`: Strings describing the card.
+- `imageUrl`, `tcgplayerUrl`: External references.
+- `marketPrice`, `lowPrice`, `midPrice`, `highPrice`, `directLowPrice`: Pricing metrics.
+- `createdAt`, `updatedAt`: Timestamps for import tracking.
+
+## `buylist_entries`
+- `internalId`: String (references `products.internalId`).
+- `priceMultiplier`: Decimal; multiplier applied to a reference price.
+- `priceOverride`: Decimal; optional fixed payout.
+- `maxQuantity`: Integer limit per store-defined timeframe.
+- `disabled`: Boolean indicating customer visibility.
+- `notes`: Optional text for internal instructions.
+- `createdBy`, `updatedBy`: User references (username or user ID).
+- `createdAt`, `updatedAt`: Timestamps.
+
+## `buylist_progress`
+- `internalId`: String (references `products.internalId`).
+- `maxQuantity`: Integer; system-enforced limit.
+- `pendingQuantity`: Integer; carts submitted but not processed.
+- `boughtQuantity`: Integer; total accepted/processed quantity.
+- `autoDisabledAt`: Timestamp when the item was auto-disabled.
+- `updatedAt`: Timestamp of last recalculation.
+
+## `buy_carts`
+- `cartId`: ObjectId.
+- `status`: Enum (`draft`, `submitted`, `accepted`, `processed`, `reviewed`, `finalized`, `completed`, `cancelled`).
+- `username`: String (customer reference) or `null` for guest carts.
+- `dropOffType`: Enum (`in_store`, `shipping`).
+- `items`: Array of subdocuments with `internalId`, `requestedCondition`, `requestedQuantity`, `verifiedCondition`, `verifiedQuantity`, `payoutEach`, `notes`.
+- `payout`: Subdocument with `cash`, `credit`, `creditBonus`.
+- `history`: Array of status changes with timestamps, actor, and notes.
+- `attachments`: Array of file metadata references.
+- `employeeName`, `processedBy`: Strings referencing employees.
+- `createdAt`, `submittedAt`, `processedAt`, `reviewedAt`, `finalizedAt`, `completedAt`, `cancelledAt`.
+- `managerCorrections`: Array of corrections applied during review.
+
+## `users`
+- `userId`: ObjectId.
+- `username`: Unique string.
+- `passwordHash`: Hashed password.
+- `role`: Enum (`customer`, `employee`, `manager`, `admin`).
+- `contact`: Subdocument with email, phone, and notification preferences.
+- `status`: Enum (`active`, `inactive`, `locked`).
+- `createdAt`, `updatedAt`, `lastLoginAt`.
+
+## `server_settings`
+- `storeName`: String.
+- `creditBoostPercentage`: Decimal.
+- `conditionPercentages`: Map of condition to payout percentage.
+- `enabledCategories`: Array of category IDs.
+- `allowUserAccounts`, `allowInStoreDropOff`, `allowShippedDropOff`: Booleans.
+- `announcementBanner`: Optional string.
+- `updatedBy`: User reference.
+- `updatedAt`: Timestamp.
+
+## `audit_logs`
+- `logId`: ObjectId.
+- `action`: String identifier.
+- `collectionName`: String.
+- `documentId`: Reference to affected document.
+- `performedBy`: User reference.
+- `timestamp`: Timestamp.
+- `details`: JSON object capturing before/after deltas.
+- `ipAddress`, `userAgent`: Optional metadata.
+
+## `emergency_disables`
+- `ruleId`: ObjectId.
+- `type`: Enum (`group`, `category`, `product`).
+- `targetId`: Identifier for the disabled entity.
+- `reason`: Text.
+- `disabledBy`: User reference.
+- `disabledAt`: Timestamp.
+- `expiresAt`: Optional timestamp for auto re-enable.
+
+## `inventory_imports`
+- `importId`: ObjectId.
+- `status`: Enum (`draft`, `generated`, `exported`, `synced`).
+- `cartIds`: Array of `buy_carts.cartId`.
+- `totals`: Array of per-product aggregates (internalId, quantity, payout, condition mix).
+- `summary`: Totals for cash, credit, cards count.
+- `exportMetadata`: Subdocument (format, file references, generatedAt, generatedBy).
+- `notes`: Text.
+- `createdAt`, `updatedAt`.
+
+## `import_runs`
+- `runId`: ObjectId.
+- `type`: Enum (`tcgcsv`).
+- `status`: Enum (`pending`, `running`, `succeeded`, `failed`).
+- `startedAt`, `completedAt`.
+- `stats`: JSON object with counts (inserted, updated, skipped).
+- `error`: Optional error message/stack trace.
+
+## `analytics_cache`
+- `cacheId`: ObjectId.
+- `metric`: String identifier (e.g., `spend_summary-weekly`).
+- `parameters`: JSON object describing filters.
+- `data`: Aggregated results snapshot.
+- `generatedAt`: Timestamp.
+- `expiresAt`: Timestamp for cache invalidation.

--- a/docs/frontend_pages.md
+++ b/docs/frontend_pages.md
@@ -1,0 +1,38 @@
+# Frontend Pages
+
+## Public Experience
+- **Landing / Buylist Explorer**: Highlights store information, featured categories, and quick links to search.
+- **Product Search & Results**: Search bar, filters, pagination, and inline add-to-cart capability.
+- **Product Detail Modal/Page**: Detailed pricing, conditions, quantity limits, recent status updates, and add-to-cart controls.
+- **Cart Builder**: Displays selected items, allows editing conditions/quantities, shows payout summary, and enforces validation rules.
+- **Submission Confirmation**: Shows submission details, drop-off instructions, and tracking information.
+- **Cart Status Tracker**: Provides timeline of status changes, messages, and ability to cancel or respond to requests.
+
+## Authentication & Account
+- **Login / Register**: Unified authentication interface with support for guest submissions if enabled.
+- **Profile & Preferences**: Manage contact info, notification preferences, and saved drop-off options.
+- **Password Reset**: Initiate and complete password reset flows.
+
+## Employee Operations (Authenticated)
+- **Dashboard / Queue**: Overview of submitted carts requiring action, with filters and status indicators.
+- **Cart Processing Workspace**: Item-by-item verification, condition adjustments, payout calculation, note-taking, and submission controls.
+- **Attachment Manager**: Upload and review supporting photos/documents for a cart.
+
+## Management
+- **Processed Cart Review**: List of processed carts awaiting manager review with quick stats.
+- **Cart Correction View**: Detailed review interface to adjust quantities, conditions, payouts, and notes.
+- **Import Batch Builder**: Select reviewed carts, preview aggregated totals, and finalize import batches.
+- **Import History & Export Downloads**: View past imports, download export files, and audit changes.
+- **Analytics Dashboard**: Visualizations for spend, category trends, employee performance, and inventory impact.
+
+## Administration
+- **Buylist Management**: CRUD UI for buylist entries, price overrides, and disabled state management.
+- **Progress Monitor**: View buy limits, purchased quantities, and auto-disable thresholds.
+- **Emergency Disable Console**: Trigger or revoke group/category-level disables with reasoning.
+- **Settings Panel**: Configure store settings, credit bonuses, condition percentages, and drop-off options.
+- **User & Role Management**: Invite users, assign roles, reset passwords, and deactivate accounts.
+- **Audit Log Viewer**: Searchable, filterable log of all significant actions.
+
+## System Utilities
+- **Import Job Monitor**: View scheduled TCGCSV import history, retry failed jobs, and download logs.
+- **Health Status**: Service uptime, metrics overview, and incident reporting.

--- a/docs/implementation_plan.md
+++ b/docs/implementation_plan.md
@@ -1,0 +1,49 @@
+# Long-Term Implementation Plan
+
+## Phase 0: Foundations (Weeks 0-2)
+- Finalize project requirements, architecture diagrams, and development environment setup.
+- Establish repository structure, coding standards, and contribution guidelines.
+- Configure CI/CD pipeline with linting, testing, and security scans.
+- Provision development MongoDB instance and seed sample data.
+- Implement authentication scaffold (JWT, user roles) and base React app shell.
+
+## Phase 1: Public Buylist & Cart (Weeks 3-6)
+- Integrate TCGCSV import scheduler and baseline product data ingestion.
+- Build public buylist endpoints and React pages with search/filter UX.
+- Implement cart drafting, validation, and submission flows.
+- Add email notifications for submission confirmations.
+- Write end-to-end tests covering customer journey.
+
+## Phase 2: Employee Processing (Weeks 7-10)
+- Develop employee queue, cart acceptance, and processing endpoints.
+- Create processing UI with condition verification and payout calculators.
+- Enable attachment uploads and secure storage.
+- Implement audit logging for employee actions.
+- Conduct usability testing with intake staff and refine workflows.
+
+## Phase 3: Manager Review & Inventory Intake (Weeks 11-14)
+- Build manager review dashboard and correction endpoints/UI.
+- Implement inventory import batch creation and tracking.
+- Generate export files (initial focus on Shopify CSV) with validation.
+- Add reconciliation tools to compare processed vs corrected items.
+- Expand automated test coverage to include manager workflows.
+
+## Phase 4: Administration & Analytics (Weeks 15-18)
+- Implement full buylist management UI and emergency disable controls.
+- Build system settings pages with audit logging and guardrails.
+- Deliver analytics dashboards and reporting APIs.
+- Add data caching strategies for expensive analytics queries.
+- Harden security (rate limiting, permissions audit, vulnerability scans).
+
+## Phase 5: Deployment & Operations (Weeks 19-22)
+- Prepare production deployment scripts/documentation (Docker, systemd, etc.).
+- Configure monitoring (metrics, logs, uptime checks) and alerting.
+- Establish backup/restore routines for MongoDB and file storage.
+- Conduct load testing and performance tuning.
+- Plan staged rollout with pilot stores, gather feedback, and iterate.
+
+## Ongoing Initiatives
+- Maintain TODO roadmap and planning documents as features ship.
+- Schedule quarterly reviews of pricing algorithms and analytics efficacy.
+- Continuously improve accessibility, localization, and documentation.
+- Evaluate integration opportunities with additional marketplaces.

--- a/docs/required_features.md
+++ b/docs/required_features.md
@@ -1,0 +1,41 @@
+# Required Features
+
+## Public & Customer Experience
+- Discoverable buylist with search, filters (category, group, rarity), and price indicators.
+- Customer authentication with optional guest submission (respecting configuration).
+- Cart builder with condition selection, quantity controls, and price validation.
+- Submission workflow supporting shipping and in-store drop-off, including instructions and acknowledgments.
+- Real-time status tracking and notifications for cart updates.
+
+## Employee Operations
+- Queue of submitted carts with prioritization and filtering.
+- Cart processing workspace capturing condition verification, quantity adjustments, and payout calculations.
+- Support for notes, discrepancies, and photo attachments.
+- Ability to cancel carts or items with audit logging.
+
+## Management & Inventory
+- Review dashboard for processed carts awaiting correction or intake.
+- Correction interface to adjust quantities, conditions, payouts, and add manager notes.
+- Bulk finalize carts into inventory import batches with summary metrics.
+- Export generation (e.g., Shopify CSV) with configurable templates.
+- Post-export tracking of completed carts and import history.
+
+## Administration & Configuration
+- Buylist configuration tools (price overrides, multipliers, disabled items/groups/categories).
+- System settings management (store info, credit bonus, condition percentages, drop-off options).
+- Emergency disable controls and logging.
+- User management (roles: customer, employee, manager, admin) with role-based access control.
+- Audit log viewer with filtering and export.
+
+## Data Integrations & Maintenance
+- Scheduled imports from TCGCSV API with error handling and delta updates.
+- Inventory export integrations with third-party systems.
+- Analytics reporting for spend, category trends, employee performance, and inventory impact.
+- Backup and restore procedures for MongoDB and configuration data.
+
+## Non-Functional Requirements
+- Secure authentication (JWT), HTTPS support, and least-privilege access.
+- Responsive and accessible frontend (React + Tailwind).
+- Observability: structured logging, metrics, and alerting.
+- Scalability to handle multiple concurrent cart submissions and processing sessions.
+- Comprehensive test coverage and CI/CD pipeline readiness.

--- a/docs/user_story_narrative.md
+++ b/docs/user_story_narrative.md
@@ -1,0 +1,28 @@
+# User Story Narrative
+
+## Primary Personas
+- **Customer (Seller)**: Trading card enthusiasts who want to sell cards to the store.
+- **Intake Employee**: Staff receiving and validating cards dropped off or shipped in.
+- **Inventory Manager**: Staff member responsible for reviewing processed carts and syncing inventory to downstream systems.
+- **Administrator/Owner**: Oversees pricing strategy, system settings, and audit compliance.
+
+## Scenario Overview
+1. **Discovering the Buylist**: A customer navigates to the public buylist interface to check which cards the store is currently buying and at what price.
+2. **Preparing a Submission**: The customer searches for cards, adds them to a cart, selects the intended condition and quantity, and reviews pricing rules and requirements.
+3. **Submitting the Cart**: After verifying identity (account or guest as allowed), the customer submits the cart, chooses a drop-off or shipping option, and receives confirmation with next steps.
+4. **Physical Intake**: The intake employee retrieves the submitted cart, verifies card conditions and quantities, adjusts payouts as necessary, and updates the cart status.
+5. **Manager Review**: The inventory manager reviews processed carts, makes corrections for any discrepancies, and confirms carts are ready for inventory intake.
+6. **Inventory Sync**: The manager aggregates approved carts into an inventory import, exports data in the required format (e.g., Shopify CSV), and marks the carts as completed.
+7. **Continuous Improvement**: Administrators analyze spend analytics, adjust buylist pricing, manage emergency disables, and audit actions to keep operations compliant and profitable.
+
+## Goals & Pain Points
+- Customers want a transparent, up-to-date list of cards with fair pricing and a frictionless submission process.
+- Employees need streamlined workflows to process cards accurately and reduce manual data entry.
+- Managers require clear visibility into processed carts, error correction tools, and reliable exports to their inventory systems.
+- Administrators demand complete control over pricing, settings, and audit trails to meet compliance and business objectives.
+
+## Success Criteria
+- Customers can confidently submit carts and track status changes.
+- Employees can process carts efficiently with condition-based payouts and audit logging.
+- Managers can reconcile processed carts, finalize accurate inventory imports, and generate exports without duplication.
+- Stakeholders have accessible analytics and system controls to adapt operations quickly.

--- a/docs/user_story_walkthrough.md
+++ b/docs/user_story_walkthrough.md
@@ -1,0 +1,42 @@
+# User Story Walkthrough (Endpoint by Endpoint)
+
+## 1. Customer Discovers the Buylist
+- `GET /buylist/products` — Customer browses available cards using filters.
+- `GET /buylist/settings` — Frontend retrieves store policies and drop-off options.
+- `GET /buylist/products/{internalId}` — Customer reviews details for each card before adding to cart.
+
+## 2. Customer Builds and Submits a Cart
+- `GET /carts/current` — Load any in-progress draft cart.
+- `POST /carts` — Save cart changes while selecting conditions and quantities.
+- `POST /auth/register` or `POST /auth/login` — Authenticate as needed (optional for guests depending on configuration).
+- `POST /carts/submit` — Validate limits, lock pricing, and transition cart to `submitted` status.
+- Notification is sent via internal messaging queue/integration (future enhancement).
+
+## 3. Employee Intake & Processing
+- `GET /carts?status=submitted` — Employee dashboard shows carts awaiting action.
+- `POST /processing/{cartId}/accept` — Employee claims the cart for processing.
+- `POST /processing/{cartId}/items` — Record actual verified card conditions and quantities.
+- `POST /processing/{cartId}/attachments` — Upload photos or supporting documents (if necessary).
+- `POST /processing/{cartId}/complete` — Finalize payouts, update history, and set status to `processed`.
+
+## 4. Manager Review & Corrections
+- `GET /inventory/processed` — Manager views processed carts pending review.
+- `GET /carts/{cartId}` — Manager reviews detailed processing history.
+- `POST /inventory/review/{cartId}` — Apply corrections for discrepancies or policy adjustments.
+
+## 5. Inventory Import Preparation
+- `POST /inventory/finalize` — Select reviewed carts to create an `inventory_imports` batch.
+- `GET /inventory/imports/{importId}` — Review aggregated totals and ensure data accuracy.
+
+## 6. Export & Completion
+- `GET /inventory/export/{importId}` — Generate formatted export (e.g., Shopify CSV) for downstream systems.
+- `PATCH /inventory/imports/{importId}` (future) — Mark export as synced once imported into external inventory.
+- `GET /inventory/imports` — Track import history and completion status.
+
+## 7. Continuous Improvement & Administration
+- `GET /admin/buylist` — Administrators adjust pricing and availability.
+- `POST /admin/buylist` — Update price overrides and multipliers based on analytics.
+- `GET /admin/settings` / `PATCH /admin/settings` — Modify store-wide policies and configuration.
+- `POST /admin/emergency-disable` — React quickly to market shifts by disabling categories or groups.
+- `GET /analytics/spend-summary` — Monitor spend trends to guide future buylist decisions.
+- `GET /admin/audit-logs` — Review actions for compliance and troubleshooting.


### PR DESCRIPTION
## Summary
- add a comprehensive planning document suite covering user stories, features, endpoints, frontend pages, data models, and implementation phases
- refresh the README to reference the new documents and present an updated project overview
- establish repository-wide agent guidelines and an actionable TODO tracker for ongoing work

## Testing
- not run (documentation and planning updates only)


------
https://chatgpt.com/codex/tasks/task_e_68decd3dcf488320b7de00af2f7ff2d2