### PR TITLE
Scaffold Flask backend and document environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Maintain the planning documents in the `docs/` directory. Update them whenever scope, features, or architecture change.
 - Keep `README.md` aligned with the current state of the project and reference newly added documents.
 - Preserve the data model and endpoint summaries when expanding functionality.
+- Document every new model, endpoint, or noteworthy architectural detail in the appropriate `docs/` reference and link to it here. Future contributors must review those documents before modifying the scoped areas.
 
 ## TODO Management
 - Always keep `TODO.md` up to date with feature status, milestones, and notes for future developers.
@@ -14,6 +15,11 @@
 - Follow the feature roadmap defined in `docs/implementation_plan.md` unless requirements shift.
 - Ensure new endpoints, pages, or models include corresponding documentation updates.
 - Maintain auditability by noting significant design decisions in commit messages and documentation.
+
+## Documentation References
+- Backend architecture, extensions, and blueprint usage are described in `docs/backend_architecture.md`.
+- Development environment setup steps and required tooling are detailed in `docs/development_environment.md`.
+- Update this section whenever new authoritative documentation is added so future requests can find the relevant instructions quickly.
 
 ## Communication
 - Summaries and PR descriptions should clearly state affected areas, testing performed, and any follow-up actions required.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,13 @@ BuyLyst.co is a full-stack Python + MongoDB + React application for trading card
 - [Backend Endpoints](docs/backend_endpoints.md)
 - [Frontend Pages](docs/frontend_pages.md)
 - [Database Collections & Models](docs/database_models.md)
+- [Backend Architecture Overview](docs/backend_architecture.md)
+- [Development Environment Setup](docs/development_environment.md)
 - [User Story Walkthrough](docs/user_story_walkthrough.md)
 - [Long-Term Implementation Plan](docs/implementation_plan.md)
+
+## Getting Started
+Refer to [Development Environment Setup](docs/development_environment.md) for Python, MongoDB, and tooling prerequisites. The current backend scaffold lives in `backend/` and exposes a readiness probe at `GET /api/health/`.
 
 ## Data Model Summary
 - **products**: Imported from TCGCSV; includes IDs, taxonomy, metadata, and price metrics.

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,9 @@
 - [x] Establish repository-wide agent guidelines.
 
 ## Phase 0: Foundations
-- [ ] Define development environment setup instructions.
+- [x] Define development environment setup instructions.
+  - Documented in [docs/development_environment.md](docs/development_environment.md) covering prerequisites, environment variables, and launch commands.
+  - Backend scaffold includes healthcheck endpoint for verifying environment wiring.
 - [ ] Configure CI/CD pipeline (linting, testing, security scans).
 - [ ] Provision shared MongoDB instances and seed datasets.
 - [ ] Implement authentication scaffold (JWT, roles) in codebase.
@@ -47,3 +49,4 @@
 - Align feature implementation with the [Long-Term Implementation Plan](docs/implementation_plan.md).
 - Update relevant documents and this tracker immediately after each feature milestone progresses.
 - Capture emerging risks, decisions, and follow-ups directly under the affected phase.
+- Backend architecture reference added at [docs/backend_architecture.md](docs/backend_architecture.md); consult before modifying Flask modules or introducing new blueprints.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,19 @@
+"""Application factory for the BuyLyst backend."""
+from __future__ import annotations
+
+from flask import Flask
+
+from . import routes
+from .config import Config
+from .extensions import init_extensions
+
+
+def create_app(config: type[Config] | None = None) -> Flask:
+    """Create and configure the Flask application instance."""
+    app = Flask(__name__)
+    app.config.from_object(config or Config)
+
+    init_extensions(app)
+    routes.register_blueprints(app)
+
+    return app

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,18 @@
+"""Configuration management for the BuyLyst backend."""
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+
+class Config:
+    """Default configuration values for all environments."""
+
+    SECRET_KEY: str = os.environ.get("BUYLYST_SECRET_KEY", "dev-secret-change-me")
+    MONGO_URI: str = os.environ.get("BUYLYST_MONGO_URI", "mongodb://localhost:27017/buylyst")
+
+    JWT_SECRET_KEY: str = os.environ.get("BUYLYST_JWT_SECRET", SECRET_KEY)
+    JWT_ACCESS_TOKEN_EXPIRES: timedelta = timedelta(minutes=30)
+
+    SCHEDULER_API_ENABLED: bool = False
+    ENV: str = os.environ.get("FLASK_ENV", "development")

--- a/backend/app/extensions.py
+++ b/backend/app/extensions.py
@@ -1,0 +1,15 @@
+"""Extension registry for the BuyLyst backend."""
+from __future__ import annotations
+
+from flask import Flask
+from flask_jwt_extended import JWTManager
+from flask_pymongo import PyMongo
+
+jwt = JWTManager()
+mongo = PyMongo()
+
+
+def init_extensions(app: Flask) -> None:
+    """Bind shared extensions to the provided Flask app."""
+    jwt.init_app(app)
+    mongo.init_app(app)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,17 @@
+"""Route blueprints for the BuyLyst backend."""
+from __future__ import annotations
+
+from flask import Blueprint, Flask, jsonify
+
+health_bp = Blueprint("health", __name__, url_prefix="/api/health")
+
+
+@health_bp.get("/")
+def healthcheck() -> tuple[dict[str, str], int]:
+    """Basic healthcheck endpoint used for readiness probes."""
+    return jsonify(status="ok"), 200
+
+
+def register_blueprints(app: Flask) -> None:
+    """Register all application blueprints."""
+    app.register_blueprint(health_bp)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.0.2
+flask-jwt-extended==4.6.0
+flask-pymongo==2.3.0

--- a/backend/wsgi.py
+++ b/backend/wsgi.py
@@ -1,0 +1,10 @@
+"""WSGI entrypoint for running the BuyLyst backend."""
+from __future__ import annotations
+
+from app import create_app
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000, debug=True)

--- a/docs/backend_architecture.md
+++ b/docs/backend_architecture.md
@@ -1,0 +1,39 @@
+# Backend Architecture Overview
+
+This document describes the backend structure, including modules, extensions, and endpoint registration. Update it whenever new packages, blueprints, or data access layers are introduced.
+
+## Directory Layout
+```
+backend/
+├── app/
+│   ├── __init__.py        # Application factory
+│   ├── config.py          # Environment configuration
+│   ├── extensions.py      # Flask extension initialization (JWT, Mongo)
+│   └── routes/
+│       └── __init__.py    # Blueprint definitions (healthcheck scaffold)
+├── requirements.txt       # Backend dependencies
+└── wsgi.py                # Entry point for local development
+```
+
+## Application Factory
+`create_app` loads configuration from `Config`, initializes shared extensions, and registers blueprints. All future modules should expose a `register_<component>` function invoked inside the factory to keep the startup sequence explicit.
+
+## Configuration
+`Config` centralizes environment variables for secrets, MongoDB, and JWT settings. Add new configuration values here and document them in [development_environment.md](development_environment.md).
+
+## Extensions
+`extensions.py` defines singletons for JWT and MongoDB. Additional services (e.g., Celery, caching) should also be registered here with helper functions to attach them to the Flask app.
+
+## Routes
+The healthcheck blueprint is located under `app/routes`. Future blueprints should live in submodules (e.g., `app/routes/buylist.py`) and be registered by updating `register_blueprints`.
+
+## Data Access
+Direct MongoDB access is currently provided through `flask_pymongo.PyMongo`. Phase 1 will introduce repository abstractions documented alongside the relevant models.
+
+## Testing Strategy
+Unit tests will target blueprints and services using Flask's test client. Integration tests will spin up a test database via fixtures once CI is configured.
+
+## Related Documents
+- [Development Environment Setup](development_environment.md)
+- [Database Collections & Models](database_models.md)
+- [Backend Endpoints](backend_endpoints.md)

--- a/docs/development_environment.md
+++ b/docs/development_environment.md
@@ -1,0 +1,41 @@
+# Development Environment Setup
+
+This document outlines the tooling required to build and run BuyLyst locally. Every time a new dependency or tool is introduced, update this guide and reference it from relevant TODO items.
+
+## Prerequisites
+- **Python 3.11** (backend services)
+- **Node.js 20.x** and **npm 10+** (frontend build tooling, to be added in later phases)
+- **MongoDB 6.x** running locally or accessible via URI
+- **Redis** (planned for job queue/backfill work in later phases)
+- **Poetry 1.7+** or `pip` for managing backend dependencies (currently using `requirements.txt` for the Flask scaffold)
+
+## Environment Variables
+Set the following environment variables when running the backend:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `BUYLYST_SECRET_KEY` | Flask secret key | `dev-secret-change-me` |
+| `BUYLYST_MONGO_URI` | MongoDB connection string | `mongodb://localhost:27017/buylyst` |
+| `BUYLYST_JWT_SECRET` | JWT signing secret | Falls back to `BUYLYST_SECRET_KEY` |
+| `FLASK_ENV` | Flask environment flag | `development` |
+
+## Backend Setup Steps
+1. `cd backend`
+2. Create a virtual environment: `python -m venv .venv`
+3. Activate the environment: `source .venv/bin/activate`
+4. Install dependencies: `pip install -r requirements.txt`
+5. Export environment variables (see above).
+6. Launch the development server: `flask --app wsgi run --debug`
+
+The current backend exposes a healthcheck at `GET /api/health/`. Additional endpoints will be added per the implementation plan.
+
+## Frontend Setup (Placeholder)
+Frontend scaffolding is not yet committed. Once created, this section will document the React project structure, dependency installation, and development commands.
+
+## Tooling Notes
+- Use `pre-commit` hooks (to be configured in upcoming tasks) for linting and formatting enforcement.
+- Docker compose definitions will be introduced once services beyond MongoDB are required.
+
+## References
+- [Backend Architecture Overview](backend_architecture.md)
+- [Implementation Plan](implementation_plan.md)


### PR DESCRIPTION
## Summary
- add initial Flask backend scaffold with a healthcheck blueprint and extension wiring
- document environment setup and backend architecture, linking them from agent guidance and README
- update TODO tracking to reflect completed setup work

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68dee28f72fc83209ff49ad2fdf7fafb